### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/runChecks.yml
+++ b/.github/workflows/runChecks.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.8
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/runChecks.yml
+++ b/.github/workflows/runChecks.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: 3.8
     - name: Install dependencies


### PR DESCRIPTION
[checkout](https://github.com/actions/checkout) updated to v3 and [setup Python](https://github.com/actions/setup-python) actions have been updated to v4.

There is no upgrade guide for either of these actions, but no notes of backwards incompatibility.