### PR TITLE
Add 2022.2.3, 2022.2.4 and 2022.3 to NVDA API versions

### DIFF
--- a/nvdaAPIVersions.json
+++ b/nvdaAPIVersions.json
@@ -232,5 +232,18 @@
 			"minor": 1,
 			"patch": 0
 		}
+	},
+	{
+		"description": "NVDA 2022.2.3",
+		"apiVer": {
+			"major": 2022,
+			"minor": 2,
+			"patch": 3
+		},
+		"backCompatTo": {
+			"major": 2022,
+			"minor": 1,
+			"patch": 0
+		}
 	}
 ]

--- a/nvdaAPIVersions.json
+++ b/nvdaAPIVersions.json
@@ -258,5 +258,18 @@
 			"minor": 1,
 			"patch": 0
 		}
+	},
+	{
+		"description": "NVDA 2022.3",
+		"apiVer": {
+			"major": 2022,
+			"minor": 3,
+			"patch": 0
+		},
+		"backCompatTo": {
+			"major": 2022,
+			"minor": 1,
+			"patch": 0
+		}
 	}
 ]

--- a/nvdaAPIVersions.json
+++ b/nvdaAPIVersions.json
@@ -245,5 +245,18 @@
 			"minor": 1,
 			"patch": 0
 		}
+	},
+	{
+		"description": "NVDA 2022.2.4",
+		"apiVer": {
+			"major": 2022,
+			"minor": 2,
+			"patch": 4
+		},
+		"backCompatTo": {
+			"major": 2022,
+			"minor": 1,
+			"patch": 0
+		}
 	}
 ]


### PR DESCRIPTION
After merging, re-run the last "Transform NVDA addons to views" on [addon-datastore](https://github.com/nvaccess/addon-datastore/actions) to regenerate projections (views) for the add-on datastore API.