### PR TITLE
Add 2022.3.1 to NVDA API Versions

### DIFF
--- a/nvdaAPIVersions.json
+++ b/nvdaAPIVersions.json
@@ -271,5 +271,18 @@
 			"minor": 1,
 			"patch": 0
 		}
+	},
+	{
+		"description": "NVDA 2022.3.1",
+		"apiVer": {
+			"major": 2022,
+			"minor": 3,
+			"patch": 1
+		},
+		"backCompatTo": {
+			"major": 2022,
+			"minor": 1,
+			"patch": 0
+		}
 	}
 ]


### PR DESCRIPTION
After merging:
Re-run the last "Transform NVDA addons to views" on addon-datastore to regenerate projections (views) for the add-on datastore API.