### PR TITLE
Add 2022.3.2 to NVDA API versions

### DIFF
--- a/nvdaAPIVersions.json
+++ b/nvdaAPIVersions.json
@@ -284,5 +284,18 @@
 			"minor": 1,
 			"patch": 0
 		}
+	},
+	{
+		"description": "NVDA 2022.3.2",
+		"apiVer": {
+			"major": 2022,
+			"minor": 3,
+			"patch": 2
+		},
+		"backCompatTo": {
+			"major": 2022,
+			"minor": 1,
+			"patch": 0
+		}
 	}
 ]


### PR DESCRIPTION
After merging, re-run the last "Transform NVDA addons to views" on addon-datastore to regenerate projections (views) for the add-on datastore API.