### PR TITLE
Add 2022.3.3 and 2022.4 to nvdaAPIVersions.json

### DIFF
--- a/nvdaAPIVersions.json
+++ b/nvdaAPIVersions.json
@@ -297,5 +297,31 @@
 			"minor": 1,
 			"patch": 0
 		}
+	},
+	{
+		"description": "NVDA 2022.3.3",
+		"apiVer": {
+			"major": 2022,
+			"minor": 3,
+			"patch": 3
+		},
+		"backCompatTo": {
+			"major": 2022,
+			"minor": 1,
+			"patch": 0
+		}
+	},
+	{
+		"description": "NVDA 2022.4",
+		"apiVer": {
+			"major": 2022,
+			"minor": 4,
+			"patch": 0
+		},
+		"backCompatTo": {
+			"major": 2022,
+			"minor": 1,
+			"patch": 0
+		}
 	}
 ]


### PR DESCRIPTION
After merging:

- [ ] Re-run the last "Transform NVDA addons to views" on [addon-datastore](https://github.com/nvaccess/addon-datastore/actions) to regenerate projections (views) for the add-on datastore API.