### PR TITLE
Add 2023.1 to add-on API versions

### DIFF
--- a/nvdaAPIVersions.json
+++ b/nvdaAPIVersions.json
@@ -349,5 +349,18 @@
 			"minor": 1,
 			"patch": 0
 		}
+	},
+	{
+		"description": "NVDA 2023.1",
+		"apiVer": {
+			"major": 2023,
+			"minor": 1,
+			"patch": 0
+		},
+		"backCompatTo": {
+			"major": 2023,
+			"minor": 1,
+			"patch": 0
+		}
 	}
 ]


### PR DESCRIPTION
Allow authors to declare compatibility early, so testable submissions can be published on the legacy website