### PR TITLE
Case conflict handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ This repository primarily exists to transform data from [nvaccess/addon-datastor
 
 For each NVDA version that needs to be supported by the add-on store, an entry must be added to [`nvdaAPIVersions.json`](https://github.com/nvaccess/addon-datastore-transform/blob/main/nvdaAPIVersions.json).
 This includes patch versions.
-Pre-release versions of NVDA are not supported yet.
 
 ## Overview
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 jsonschema==3.2.0
+requests==2.28.2
 tox~=3.24

--- a/src/transform/datastructures.py
+++ b/src/transform/datastructures.py
@@ -5,6 +5,8 @@
 from dataclasses import dataclass
 from typing import Dict, Literal, NamedTuple
 
+from requests.structures import CaseInsensitiveDict
+
 # These values are validated using runtime validation -> see addon_data.schema.json
 AddonChannels = Literal["beta", "stable", "dev"]
 
@@ -39,4 +41,11 @@ WriteableAddons = Dict[MajorMinorPatch, AddonChannelDict]
 
 
 def generateAddonChannelDict() -> AddonChannelDict:
-	return {"beta": {}, "stable": {}, "dev": {}}
+	# Identical add-on IDs may have different casing
+	# due to legacy add-on submissions.
+	# This can be removed when old submissions are given updated casing.
+	return {
+		"beta": CaseInsensitiveDict(),
+		"stable": CaseInsensitiveDict(),
+		"dev": CaseInsensitiveDict(),
+	}

--- a/src/transform/transform.py
+++ b/src/transform/transform.py
@@ -105,8 +105,14 @@ def writeAddons(addonDir: str, addons: WriteableAddons) -> None:
 				latestAddonWriteDir = f"{addonDir}/latest/{addonName}"
 				Path(latestAddonWriteDir).mkdir(parents=True, exist_ok=True)
 				latestAddonWritePath = f"{latestAddonWriteDir}/{channel}.json"
-				if latestAddonWritePath not in latestAddonWritePaths:
-					latestAddonWritePaths.add(latestAddonWritePath)
+				# paths are case insensitive
+				# Identical add-on IDs may have different casing
+				# due to legacy add-on submissions.
+				# This can be removed when old submissions are given updated casing.
+				caseInsensitiveLatestAddonPath = latestAddonWritePath.lower()
+				if caseInsensitiveLatestAddonPath not in latestAddonWritePaths:
+					log.error(f"Latest version: {addonName} {channel} {nvdaAPIVersion}")
+					latestAddonWritePaths.add(caseInsensitiveLatestAddonPath)
 					with open(latestAddonWritePath, "w") as latestAddonFile:
 						json.dump(addonData, latestAddonFile)
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
 	flake8==3.7.9
 	flake8-tabs==2.2.2
 	nose==1.3.7
+	requests==2.28.2
 
 # Either command returning non-zero will cause a a failure "InvocationError"
 # Ignore return code by prefixing '--'


### PR DESCRIPTION
An author may manually update the casing of their add-on ID, but misses an add-on submission in the update.
This causes 2 different casing of the addonID field, in the same add-on folder.
This can cause the views to be generated incorrectly.

While casing failures have been fixed in the datastore now, handling case conflicts will prevent the views from generating incorrectly.

Case updates:
https://github.com/nvaccess/addon-datastore/commit/b8e106814a836e6c6ea79a6c21e2f9ef17e6993e
https://github.com/nvaccess/addon-datastore/commit/cb5767671dda722a69639fa98055ad4d02d5e487
