### PR TITLE
Generate translated views from add-on data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 jsonschema==3.2.0
-requests==2.28.2
+requests==2.31.0
 tox~=3.24

--- a/src/tests/test_viewsGenerationSystem.py
+++ b/src/tests/test_viewsGenerationSystem.py
@@ -171,12 +171,12 @@ class TestTransformation(unittest.TestCase):
 		)
 		self.runTransformation()
 		self._assertAddonDataWritten(
-			ExpectedAddonVersion('2020.2.0/oldNewAddon/stable.json', '2.1.0'),
-			ExpectedAddonVersion('2020.3.0/oldNewAddon/stable.json', '13.0.0'),  # overrides 2.1.0
-			ExpectedAddonVersion('2020.4.0/oldNewAddon/stable.json', '13.0.0'),
-			ExpectedAddonVersion('2020.4.0/betaStableAddon/stable.json', '0.0.1'),
-			ExpectedAddonVersion('2020.4.0/betaStableAddon/beta.json', '0.0.2'),
-			ExpectedAddonVersion('latest/betaStableAddon/beta.json', '0.0.2'),
-			ExpectedAddonVersion('latest/betaStableAddon/stable.json', '0.0.1'),
-			ExpectedAddonVersion('latest/oldNewAddon/stable.json', '13.0.0'),
+			ExpectedAddonVersion('en/2020.2.0/oldNewAddon/stable.json', '2.1.0'),
+			ExpectedAddonVersion('en/2020.3.0/oldNewAddon/stable.json', '13.0.0'),  # overrides 2.1.0
+			ExpectedAddonVersion('en/2020.4.0/oldNewAddon/stable.json', '13.0.0'),
+			ExpectedAddonVersion('en/2020.4.0/betaStableAddon/stable.json', '0.0.1'),
+			ExpectedAddonVersion('en/2020.4.0/betaStableAddon/beta.json', '0.0.2'),
+			ExpectedAddonVersion('en/latest/betaStableAddon/beta.json', '0.0.2'),
+			ExpectedAddonVersion('en/latest/betaStableAddon/stable.json', '0.0.1'),
+			ExpectedAddonVersion('en/latest/oldNewAddon/stable.json', '13.0.0'),
 		)

--- a/src/transform/datastructures.py
+++ b/src/transform/datastructures.py
@@ -1,9 +1,14 @@
-# Copyright (C) 2021 NV Access Limited
+# Copyright (C) 2021-2023 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
 from dataclasses import dataclass
-from typing import Dict, Literal, NamedTuple
+from typing import (
+	Dict,
+	List,
+	Literal,
+	NamedTuple,
+)
 
 from requests.structures import CaseInsensitiveDict
 
@@ -34,6 +39,7 @@ class Addon:
 	channel: AddonChannels
 	minNvdaAPIVersion: MajorMinorPatch
 	lastTestedVersion: MajorMinorPatch
+	translations: List[Dict[str, str]]
 
 
 AddonChannelDict = Dict[AddonChannels, Dict[str, Addon]]

--- a/src/transform/transform.py
+++ b/src/transform/transform.py
@@ -97,7 +97,8 @@ def writeAddons(addonDir: str, addons: WriteableAddons) -> None:
 				addonWritePath = f"{addonDir}/en/{str(nvdaAPIVersion)}/{addonName}"
 				with open(addon.pathToData, "r") as oldAddonFile:
 					addonData = json.load(oldAddonFile)
-					del addonData["translations"]
+					if "translations" in addonData:
+						del addonData["translations"]
 				Path(addonWritePath).mkdir(parents=True, exist_ok=True)
 				with open(f"{addonWritePath}/{channel}.json", "w") as newAddonFile:
 					validateJson(addonData, JSONSchemaPaths.ADDON_DATA)

--- a/src/transform/transform.py
+++ b/src/transform/transform.py
@@ -119,7 +119,7 @@ def writeAddons(addonDir: str, addons: WriteableAddons) -> None:
 						json.dump(addonData, latestAddonFile)
 
 				for translation in addon.translations:
-					lang = addonData['language']
+					lang = translation['language']
 					addonWritePath = f"{addonDir}/{lang}/{str(nvdaAPIVersion)}/{addonName}"
 					addonData["displayName"] = translation["displayName"]
 					addonData["description"] = translation["description"]

--- a/src/transform/transform.py
+++ b/src/transform/transform.py
@@ -123,11 +123,13 @@ def writeAddons(addonDir: str, addons: WriteableAddons) -> None:
 					addonWritePath = f"{addonDir}/{lang}/{str(nvdaAPIVersion)}/{addonName}"
 					addonData["displayName"] = translation["displayName"]
 					addonData["description"] = translation["description"]
+					Path(addonWritePath).mkdir(parents=True, exist_ok=True)
 					with open(f"{addonWritePath}/{channel}.json", "w") as newAddonFile:
 						validateJson(addonData, JSONSchemaPaths.ADDON_DATA)
 						json.dump(addonData, newAddonFile)
 					if addLatest:
 						latestAddonWritePath = f"{addonDir}/{lang}/latest/{addonName}"
+						Path(latestAddonWritePath).mkdir(parents=True, exist_ok=True)
 						with open(f"{latestAddonWritePath}/{channel}.json", "w") as newAddonFile:
 							validateJson(addonData, JSONSchemaPaths.ADDON_DATA)
 							json.dump(addonData, newAddonFile)

--- a/src/transform/transform.py
+++ b/src/transform/transform.py
@@ -84,7 +84,7 @@ def writeAddons(addonDir: str, addons: WriteableAddons) -> None:
 	Given a unique mapping of (nvdaAPIVersion, channel) -> addon, write the addons to file.
 	Throws a ValidationError and exits if writeable data does not match expected schema.
 	"""
-	latestAddonWritePaths: Set[str] = set()
+	writtenLatestAddonForChannel: Set[str] = set()
 	for nvdaAPIVersion in sorted(addons.keys(), reverse=True):
 		# To generate the 'latest view',
 		# check each api version, starting with the latest.
@@ -94,27 +94,42 @@ def writeAddons(addonDir: str, addons: WriteableAddons) -> None:
 		for channel in addons[nvdaAPIVersion]:
 			for addonName in addons[nvdaAPIVersion][channel]:
 				addon = addons[nvdaAPIVersion][channel][addonName]
-				addonWritePath = f"{addonDir}/{str(nvdaAPIVersion)}/{addonName}"
+				addonWritePath = f"{addonDir}/en/{str(nvdaAPIVersion)}/{addonName}"
 				with open(addon.pathToData, "r") as oldAddonFile:
 					addonData = json.load(oldAddonFile)
+					del addonData["translations"]
 				Path(addonWritePath).mkdir(parents=True, exist_ok=True)
 				with open(f"{addonWritePath}/{channel}.json", "w") as newAddonFile:
 					validateJson(addonData, JSONSchemaPaths.ADDON_DATA)
 					json.dump(addonData, newAddonFile)
 
-				latestAddonWriteDir = f"{addonDir}/latest/{addonName}"
-				Path(latestAddonWriteDir).mkdir(parents=True, exist_ok=True)
-				latestAddonWritePath = f"{latestAddonWriteDir}/{channel}.json"
+				latestAddonWritePath = f"{addonDir}/en/latest/{addonName}"
+				Path(latestAddonWritePath).mkdir(parents=True, exist_ok=True)
 				# paths are case insensitive
 				# Identical add-on IDs may have different casing
 				# due to legacy add-on submissions.
 				# This can be removed when old submissions are given updated casing.
-				caseInsensitiveLatestAddonPath = latestAddonWritePath.lower()
-				if caseInsensitiveLatestAddonPath not in latestAddonWritePaths:
+				caseInsensitiveLatestAddonForChannel = f"{addonName.lower()}-{channel}"
+				addLatest = caseInsensitiveLatestAddonForChannel not in writtenLatestAddonForChannel
+				if addLatest:
 					log.error(f"Latest version: {addonName} {channel} {nvdaAPIVersion}")
-					latestAddonWritePaths.add(caseInsensitiveLatestAddonPath)
-					with open(latestAddonWritePath, "w") as latestAddonFile:
+					writtenLatestAddonForChannel.add(caseInsensitiveLatestAddonForChannel)
+					with open(f"{latestAddonWritePath}/{channel}.json", "w") as latestAddonFile:
 						json.dump(addonData, latestAddonFile)
+
+				for translation in addon.translations:
+					lang = addonData['language']
+					addonWritePath = f"{addonDir}/{lang}/{str(nvdaAPIVersion)}/{addonName}"
+					addonData["displayName"] = translation["displayName"]
+					addonData["description"] = translation["description"]
+					with open(f"{addonWritePath}/{channel}.json", "w") as newAddonFile:
+						validateJson(addonData, JSONSchemaPaths.ADDON_DATA)
+						json.dump(addonData, newAddonFile)
+					if addLatest:
+						latestAddonWritePath = f"{addonDir}/{lang}/latest/{addonName}"
+						with open(f"{latestAddonWritePath}/{channel}.json", "w") as newAddonFile:
+							validateJson(addonData, JSONSchemaPaths.ADDON_DATA)
+							json.dump(addonData, newAddonFile)
 
 
 def readAddons(addonDir: str) -> Iterable[Addon]:
@@ -138,6 +153,7 @@ def readAddons(addonDir: str) -> Iterable[Addon]:
 			channel=addonData["channel"],
 			minNvdaAPIVersion=MajorMinorPatch(**addonData["minNVDAVersion"]),
 			lastTestedVersion=MajorMinorPatch(**addonData["lastTestedVersion"]),
+			translations=addonData.get("translations", []),
 		)
 
 

--- a/src/transform/transform.py
+++ b/src/transform/transform.py
@@ -56,7 +56,7 @@ def _addonVersionNotAlreadyAdded(addons: Dict[str, Addon], addon: Addon) -> True
 
 
 def getSupportedLanguages(addons: WriteableAddons) -> Set[str]:
-	supportedLanguages: Set[str] = {}
+	supportedLanguages: Set[str] = set()
 	for apiVersion in addons:
 		for channel in addons[apiVersion]:
 			for addonId in addons[apiVersion][channel]:

--- a/src/transform/transform.py
+++ b/src/transform/transform.py
@@ -60,7 +60,7 @@ def getSupportedLanguages(addons: WriteableAddons) -> Set[str]:
 	for apiVersion in addons:
 		for channel in addons[apiVersion]:
 			for addonId in addons[apiVersion][channel]:
-				supportedLanguages.update(t["language"] for t in addons[apiVersion][channel][addonId].translations)
+				supportedLanguages.update({t["language"] for t in addons[apiVersion][channel][addonId].translations})
 	return supportedLanguages
 
 

--- a/src/transform/transform.py
+++ b/src/transform/transform.py
@@ -61,6 +61,7 @@ def getSupportedLanguages(addons: WriteableAddons) -> Set[str]:
 		for channel in addons[apiVersion]:
 			for addonId in addons[apiVersion][channel]:
 				supportedLanguages.update(t["language"] for t in addons[apiVersion][channel][addonId].translations)
+	return supportedLanguages
 
 
 def getLatestAddons(addons: Iterable[Addon], nvdaAPIVersions: Tuple[VersionCompatibility]) -> WriteableAddons:


### PR DESCRIPTION
Using translation data parsed by https://github.com/nvaccess/addon-datastore-validation/pull/32, create translated views of each add-on

Related PRs:
- [ ] https://github.com/nvaccess/addon-datastore-validation/pull/32
- [ ] https://github.com/nvaccess/addon-datastore/pull/1095