### PR TITLE
Add missing NVDA minor versions

### DIFF
--- a/nvdaAPIVersions.json
+++ b/nvdaAPIVersions.json
@@ -1,6 +1,6 @@
 [
 	{
-		"description": "NVDA 2018.4 and earlier",
+		"description": "NVDA 2018.4.1 and earlier",
 		"apiVer": {
 			"major": 0,
 			"minor": 0,
@@ -26,6 +26,19 @@
 		}
 	},
 	{
+		"description": "NVDA 2019.1.1",
+		"apiVer": {
+			"major": 2019,
+			"minor": 1,
+			"patch": 1
+		},
+		"backCompatTo": {
+			"major": 0,
+			"minor": 0,
+			"patch": 0
+		}
+	},
+	{
 		"description": "NVDA 2019.2",
 		"apiVer": {
 			"major": 2019,
@@ -39,7 +52,20 @@
 		}
 	},
 	{
-		"description": "NVDA 2019.3",
+		"description": "NVDA 2019.2.1",
+		"apiVer": {
+			"major": 2019,
+			"minor": 2,
+			"patch": 1
+		},
+		"backCompatTo": {
+			"major": 0,
+			"minor": 0,
+			"patch": 0
+		}
+	},
+	{
+		"description": "NVDA 2019.3 and NVDA 2019.3.1",
 		"apiVer": {
 			"major": 2019,
 			"minor": 3,


### PR DESCRIPTION
Found while reviewing https://github.com/nvaccess/nvda/pull/15888

### Issue
NVDA API version json file does not cover all existing NVDA versions. These ones minor versions are missing:
* 2018.4.1
* 2019.1.1
* 2019.2.1
* 2019.3.1

I doubt any add-on is impacted by these missing minor versions. But for completeness and clarity, it's better to have them covered.

### Solution
* Fix the description of API 0.0.0 so that 2018.4.1 is covered
* Added API for 2019.1.1 and 2019.2.1
* Fixed description of 2019.3 to include also 2019.3.1. No API is added for this version since it contains only new translations; it is worth noting that this version is not listed in NVDA's change log.
