### PR TITLE
Add release2023.3.1

### DIFF
--- a/nvdaAPIVersions.json
+++ b/nvdaAPIVersions.json
@@ -416,6 +416,19 @@
 		}
 	},
 	{
+		"description": "NVDA 2023.3.1",
+		"apiVer": {
+			"major": 2023,
+			"minor": 3,
+			"patch": 1
+		},
+		"backCompatTo": {
+			"major": 2023,
+			"minor": 1,
+			"patch": 0
+		}
+	},
+	{
 		"description": "NVDA 2024.1",
 		"apiVer": {
 			"major": 2024,

--- a/nvdaAPIVersions.json
+++ b/nvdaAPIVersions.json
@@ -1,6 +1,6 @@
 [
 	{
-		"description": "NVDA 2018.4 and earlier",
+		"description": "NVDA 2018.4.1 and earlier",
 		"apiVer": {
 			"major": 0,
 			"minor": 0,
@@ -26,6 +26,19 @@
 		}
 	},
 	{
+		"description": "NVDA 2019.1.1",
+		"apiVer": {
+			"major": 2019,
+			"minor": 1,
+			"patch": 1
+		},
+		"backCompatTo": {
+			"major": 0,
+			"minor": 0,
+			"patch": 0
+		}
+	},
+	{
 		"description": "NVDA 2019.2",
 		"apiVer": {
 			"major": 2019,
@@ -39,7 +52,20 @@
 		}
 	},
 	{
-		"description": "NVDA 2019.3",
+		"description": "NVDA 2019.2.1",
+		"apiVer": {
+			"major": 2019,
+			"minor": 2,
+			"patch": 1
+		},
+		"backCompatTo": {
+			"major": 0,
+			"minor": 0,
+			"patch": 0
+		}
+	},
+	{
+		"description": "NVDA 2019.3 and NVDA 2019.3.1",
 		"apiVer": {
 			"major": 2019,
 			"minor": 3,


### PR DESCRIPTION
### Link to issue
Closes https://github.com/nvaccess/nvda/issues/16046

### Changes
NVDA 2023.3.1 patch release has just been released, but it has not been added to the json file.

### Additional notes
* I guess that the full transform should be re-run to regenerate the data with this new version
* In the future, updating this file should be listed in the patch release process/checklist. Thanks.
