### PR TITLE
Start dev cycle for 2025.1

### DIFF
--- a/nvdaAPIVersions.json
+++ b/nvdaAPIVersions.json
@@ -519,5 +519,19 @@
 			"patch": 0
 		},
 		"experimental": true
+	},
+	{
+		"description": "NVDA 2025.1",
+		"apiVer": {
+			"major": 2025,
+			"minor": 1,
+			"patch": 0
+		},
+		"backCompatTo": {
+			"major": 2025,
+			"minor": 1,
+			"patch": 0
+		},
+		"experimental": true
 	}
 ]


### PR DESCRIPTION
Added NVDA 2025.1 to `nvdaAPIVersions.json`.