### PR TITLE
Ensure json files are read and writen in utf-8

### DIFF
--- a/src/transform/transform.py
+++ b/src/transform/transform.py
@@ -104,7 +104,7 @@ def writeAddons(addonDir: str, addons: WriteableAddons, supportedLanguages: Set[
 			for addonName in addons[nvdaAPIVersion][channel]:
 				addon = addons[nvdaAPIVersion][channel][addonName]
 				addonWritePath = f"{addonDir}/en/{str(nvdaAPIVersion)}/{addonName}"
-				with open(addon.pathToData, "r") as oldAddonFile:
+				with open(addon.pathToData, "r", encoding="utf-8") as oldAddonFile:
 					addonData: Dict = json.load(oldAddonFile)
 					if "translations" in addonData:
 						del addonData["translations"]
@@ -163,7 +163,7 @@ def readAddons(addonDir: str) -> Iterable[Addon]:
 	Skips addons and logs errors if the naming schema or json schema do not match what is expected.
 	"""
 	for fileName in glob.glob(f"{addonDir}/**/*.json"):
-		with open(fileName, "r") as addonFile:
+		with open(fileName, "r", encoding="utf-8") as addonFile:
 			addonData = json.load(addonFile)
 		try:
 			validateJson(addonData, JSONSchemaPaths.ADDON_DATA)


### PR DESCRIPTION
### Summary of the issue

After normalization of add-on metadata files in addon-datastore repo, the transform action fails, as reported in nvaccess/addon-datastore#4325

### Development approach

Use `encoding="utf-8"` to read and write json files in the transform module.

### Testing performed

- Check that the transform action fails locally before this change.
- Also locally, confirm that it can be run successfully after changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved file handling by ensuring JSON files are read with UTF-8 encoding, enhancing compatibility and preventing potential issues with special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->