### PR TITLE
Remove experimental flag from 2024.4 API

### DIFF
--- a/nvdaAPIVersions.json
+++ b/nvdaAPIVersions.json
@@ -530,8 +530,7 @@
 			"major": 2024,
 			"minor": 1,
 			"patch": 0
-		},
-		"experimental": true
+		}
 	},
 	{
 		"description": "NVDA 2025.1",


### PR DESCRIPTION
Should be merged after 2024.4rc1 has successfully been built.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated NVDA versioning information, marking version 2024.4 as stable and removing its experimental status.
	- Maintained the experimental status for NVDA version 2025.1, indicating ongoing testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->