### PR TITLE
Mark 2025.2 as stable

### DIFF
--- a/nvdaAPIVersions.json
+++ b/nvdaAPIVersions.json
@@ -609,7 +609,6 @@
 			"minor": 1,
 			"patch": 0
 		},
-		"experimental": true
 	},
 	{
 		"description": "NVDA 2025.3",


### PR DESCRIPTION
Part of the 2025.2 RCSet 2025.2 as stable