### PR TITLE
Preserve data when regenerating json files from addon-datastore

### DIFF
--- a/src/validate/addon_data.schema.json
+++ b/src/validate/addon_data.schema.json
@@ -1,122 +1,157 @@
 {
-	"type": "object",
-	"additionalProperties": true,
-	"examples": [
-		{
-			"addonId": "nvdaocr",
-			"addonVersionNumber": {
-				"major": 1,
-				"minor": 3,
-				"patch": 2
+	 "type": "object",
+	 "additionalProperties": true,
+	 "examples": [
+			 {
+					 "addonId": "nvdaocr",
+					 "addonVersionNumber": {
+							 "major": 1,
+							 "minor": 3,
+							 "patch": 2
+					 },
+					 "minNVDAVersion": {
+							 "major": 2019,
+							 "minor": 3,
+							 "patch": 0
+					 },
+					 "lastTestedVersion": {
+							 "major": 2020,
+							 "minor": 4,
+							 "patch": 0
+					 },
+					 "channel": "stable"
+			 }
+	 ],
+	 "required": [
+			 "addonId",
+			 "addonVersionNumber",
+			 "minNVDAVersion",
+			 "lastTestedVersion",
+			 "channel"
+	 ],
+	 "properties": {
+			 "addonId": {
+					 "$id": "#/properties/addonId",
+					 "default": "",
+					 "examples": [
+							 "easyAddonTech.XYZ"
+					 ],
+					 "title": "The ID for the addon",
+					 "type": "string"
+			 },
+			 "addonVersionNumber": {
+					 "$ref": "#/$defs/canonicalVersion",
+					 "title": "The addon version number",
+					 "description": "Pure numerical representation of the version being released."
+			 },
+			 "minNVDAVersion": {
+					 "$ref": "#/$defs/canonicalVersion",
+					 "description": "The addon will not work with versions of NVDA prior to this version.",
+					 "title": "The minNVDAVersion required for the addon"
+			 },
+			 "lastTestedVersion": {
+					 "$ref": "#/$defs/canonicalVersion",
+					 "title": "The lastTestedVersion schema",
+					 "description": "The add-on has been tested up to and including this version of NVDA"
+			 },
+			 "channel": {
+					 "$id": "#/properties/channel",
+					 "default": "",
+					 "description": "Used to define pre-release (beta) add-ons. Should be either 'stable', 'beta' or 'dev'",
+					 "examples": [
+							 "beta"
+					 ],
+					 "title": "The channel for the addon",
+					 "enum": [
+							 "stable",
+							 "beta",
+							 "dev"
+					 ],
+					 "type": "string"
+			 }
+			,
+			"reviewUrl": {
+				"$id": "#/properties/reviewUrl",
+				"default": "",
+				"description": "A URL to the discussion comment to review the add-on version.",
+				"examples": [
+					"https://github.com/nvaccess/addon-datastore/discussions/1942#discussioncomment-7453248"
+				],
+				"title": "Discussion comment URL",
+				"type": "string"
 			},
-			"minNVDAVersion": {
-				"major": 2019,
-				"minor": 3,
-				"patch": 0
+			"vtScanUrl": {
+				"$id": "#/properties/vtScanUrl",
+				"default": "",
+				"description": "A URL to the Virus Total scan for the add-on version.",
+				"examples": [
+					"https://www.virustotal.com/gui/file/3fda88d598e9747b2dfadfdfb8930a737c0049e9782392bffcd59ef668821547"
+				],
+				"title": "VirusTotal scan URL",
+				"type": "string"
 			},
-			"lastTestedVersion": {
-				"major": 2020,
-				"minor": 4,
-				"patch": 0
-			},
-			"channel": "stable"
-		}
-	],
-	"required": [
-		"addonId",
-		"addonVersionNumber",
-		"minNVDAVersion",
-		"lastTestedVersion",
-		"channel"
-	],
-	"properties": {
-		"addonId": {
-			"$id": "#/properties/addonId",
-			"default": "",
-			"examples": [
-				"easyAddonTech.XYZ"
-			],
-			"title": "The ID for the addon",
-			"type": "string"
-		},
-		"addonVersionNumber": {
-			"$ref": "#/$defs/canonicalVersion",
-			"title": "The addon version number",
-			"description": "Pure numerical representation of the version being released."
-		},
-		"minNVDAVersion": {
-			"$ref": "#/$defs/canonicalVersion",
-			"description": "The addon will not work with versions of NVDA prior to this version.",
-			"title": "The minNVDAVersion required for the addon"
-		},
-		"lastTestedVersion": {
-			"$ref": "#/$defs/canonicalVersion",
-			"title": "The lastTestedVersion schema",
-			"description": "The add-on has been tested up to and including this version of NVDA"
-		},
-		"channel": {
-			"$id": "#/properties/channel",
-			"default": "",
-			"description": "Used to define pre-release (beta) add-ons. Should be either 'stable', 'beta' or 'dev'",
-			"examples": [
-				"beta"
-			],
-			"title": "The channel for the addon",
-			"enum": [
-				"stable",
-				"beta",
-				"dev"
-			],
-			"type": "string"
-		}
-	},
-	"$defs": {
-		"canonicalVersion": {
-			"default": {},
-			"type": "object",
-			"examples": [
-				{
-					"major": 21,
-					"minor": 6,
-					"patch": 0
-				}
-			],
-			"required": [
-				"major",
-				"minor",
-				"patch"
-			],
-			"properties": {
-				"major": {
-					"default": 0,
-					"description": "'major' in major.minor.patch",
-					"examples": [
-						21,
-						2019,
-						2021
-					],
-					"title": "The 'major' part of the version number.",
-					"type": "integer"
-				},
-				"minor": {
-					"default": 0,
-					"description": "The 'minor' part in major.minor.patch",
-					"examples": [
-						3
-					],
-					"title": "The 'minor' part of the version number.",
-					"type": "integer"
-				},
-				"patch": {
-					"default": 0,
-					"description": "The 'patch' part in major.minor.patch",
-					"examples": [
-						0
-					],
-					"title": "The 'patch' part of the version number.",
-					"type": "integer"
-				}
+			"scanResults": {
+				"$id": "#/properties/scanResults",
+				"default": {},
+				"description": "Results from dynamic and static code scanning.",
+				"examples": [
+					{
+						"virusTotal": {},
+						"codeQL-warnings": {},
+						"codeQL-errors": {}
+					}
+				],
+				"title": "Scan results",
+				"type": "object"
 			}
-		}
-	}
+	 },
+	 "$defs": {
+			 "canonicalVersion": {
+					 "default": {},
+					 "type": "object",
+					 "examples": [
+							 {
+									 "major": 21,
+									 "minor": 6,
+									 "patch": 0
+							 }
+					 ],
+					 "required": [
+							 "major",
+							 "minor",
+							 "patch"
+					 ],
+					 "properties": {
+							 "major": {
+									 "default": 0,
+									 "description": "'major' in major.minor.patch",
+									 "examples": [
+											 21,
+											 2019,
+											 2021
+									 ],
+									 "title": "The 'major' part of the version number.",
+									 "type": "integer"
+							 },
+							 "minor": {
+									 "default": 0,
+									 "description": "The 'minor' part in major.minor.patch",
+									 "examples": [
+											 3
+									 ],
+									 "title": "The 'minor' part of the version number.",
+									 "type": "integer"
+							 },
+							 "patch": {
+									 "default": 0,
+									 "description": "The 'patch' part in major.minor.patch",
+									 "examples": [
+											 0
+									 ],
+									 "title": "The 'patch' part of the version number.",
+									 "type": "integer"
+							 }
+					 }
+			 }
+	 }
 }


### PR DESCRIPTION
\### Description

In PR nvaccess/addon-datastore#7368, a bug was introduced where security data was removed from json files



\### Development approach



With assistance of Copilot, seems that when deleting translations the dictionary is mutated so that then some data is not added in the transformation.

So, instead of deleting translations directly, data is copied to a different dictionary and then added to json files as appropriate.



\### Testing performed



Currently tests are been performed at



https://github.com/nvdaes/addon-datastore/actions/runs/21413861127



\### Note



@seanbudd, if it's posible that I cannot way tonight until tests are finished. Please feel free to see results and proceed to merge if appropriate.

